### PR TITLE
Display Google authentication code next to the QR code

### DIFF
--- a/Block/Provider/Google/Configure.php
+++ b/Block/Provider/Google/Configure.php
@@ -21,9 +21,26 @@
 namespace MSP\TwoFactorAuth\Block\Provider\Google;
 
 use Magento\Backend\Block\Template;
+use Magento\Backend\Model\Auth\Session;
+use MSP\TwoFactorAuth\Model\Provider\Engine\Google;
 
 class Configure extends Template
 {
+    private $session;
+
+    /**
+     * @var Google
+     */
+    private $google;
+
+    public function __construct(Template\Context $context, Google $google, Session $session, array $data = [])
+    {
+        $this->session = $session;
+        $this->google  = $google;
+
+        parent::__construct($context, $data);
+    }
+
     /**
      * @inheritdoc
      */
@@ -37,6 +54,9 @@ class Configure extends Template
 
         $this->jsLayout['components']['msp-twofactorauth-configure']['successUrl'] =
             $this->getUrl($this->_urlBuilder->getStartupPageUrl());
+
+        $this->jsLayout['components']['msp-twofactorauth-configure']['secretCode'] =
+            $this->google->getSecretCode($this->session->getUser());
 
         return parent::getJsLayout();
     }

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -38,7 +38,10 @@
                 <resource id="Magento_Backend::stores">
                     <resource id="Magento_Backend::stores_settings">
                         <resource id="Magento_Config::config">
-                            <resource id="MSP_SecuritySuite::config">
+                            <resource id="MSP_SecuritySuite::config"
+                                      title="Security Suite"
+                                      translate="title"
+                                      sortOrder="40">
                                 <resource id="MSP_TwoFactorAuth::config"
                                           title="Two Factor Auth"
                                           translate="title"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -22,11 +22,15 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
+        <tab id="security" translate="label" sortOrder="200">
+            <label>Security</label>
+        </tab>
+
         <section id="msp_securitysuite_twofactorauth" translate="label" type="text" sortOrder="500" showInDefault="1"
                  showInWebsite="1" showInStore="1">
             <class>separator-top</class>
             <label>2FA</label>
-            <tab>general</tab>
+            <tab>security</tab>
             <resource>MSP_TwoFactorAuth::config</resource>
 
             <group id="general" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="0"

--- a/view/adminhtml/web/css/google.css
+++ b/view/adminhtml/web/css/google.css
@@ -23,3 +23,9 @@
     width: 300px;
     height: 300px;
 }
+
+.msp-tfa-google-secure-code {
+    word-wrap: break-word;
+    border: 1px solid #cccccc;
+    padding: 7px;
+}

--- a/view/adminhtml/web/js/google/auth.js
+++ b/view/adminhtml/web/js/google/auth.js
@@ -37,6 +37,7 @@ define([
         qrCodeUrl: '',
         postUrl: '',
         successUrl: '',
+        secretCode: '',
 
         /**
          * Get QR code URL
@@ -52,6 +53,15 @@ define([
          */
         getPostUrl: function () {
             return this.postUrl;
+        },
+
+        /**
+         * Get plain Secret Code
+         * @returns {string}
+         * @author Konrad Skrzynski <konrad.skrzynski@accenture.com>
+         */
+        getSecretCode: function() {
+            return this.secretCode;
         },
 
         /**

--- a/view/adminhtml/web/template/google/configure.html
+++ b/view/adminhtml/web/template/google/configure.html
@@ -28,7 +28,9 @@
 
                 <img class="msp-tfa-google-qr" attr='src: getQrCodeUrl()' />
 
-                <p data-bind='i18n: "Scan this code with your authenticator app and insert your code to confirm."'></p>
+                <p class="msp-tfa-google-secure-code" data-bind='i18n: getSecretCode()'></p>
+
+                <p data-bind='i18n: "Scan or copy&amp;paste this code with your authenticator app and insert your code to confirm."'></p>
 
                 <div class="admin__field _required field-tfa_code">
                     <label for="tfa_code" class="admin__field-label">


### PR DESCRIPTION
Since Google Authenticator only displays the QR code, it is not possible to use desktop apps like WinAuth for authentication. The changes provided in this Pull Request shows the authentication key next to the Google QR to make it possible to authenticate with desktop apps.