### PR TITLE
Fix Fatal Error in back-office when an empty or invalid TFA user configuration is present in the database

### DIFF
--- a/Model/ResourceModel/UserConfig.php
+++ b/Model/ResourceModel/UserConfig.php
@@ -102,13 +102,13 @@ class UserConfig extends AbstractDb
 
         try {
             $object->setData('config', $this->decodeConfig($object->getData('encoded_config') ?? ''));
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             $object->setData('config', []);
         }
 
         try {
             $object->setData('providers', $this->serializer->unserialize($object->getData('encoded_providers') ?? ''));
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             $object->setData('providers', []);
         }
 


### PR DESCRIPTION
In the event that the configuration is empty or invalid for an admin user, there's the following fallback behavior present in the class `\MSP\TwoFactorAuth\Model\ResourceModel\UserConfig`:
```php
    public function _afterLoad(AbstractModel $object)
    {
        parent::_afterLoad($object);

        try {
            $object->setData('config', $this->decodeConfig($object->getData('encoded_config') ?? ''));
        } catch (Exception $e) {
            $object->setData('config', []);
        }

        try {
            $object->setData('providers', $this->serializer->unserialize($object->getData('encoded_providers') ?? ''));
        } catch (Exception $e) {
            $object->setData('providers', []);
        }

        return $this;
    }
```

Unfortunately:
**if** the value cannot be decrypted **or** the empty string is provided, **then** a non-array is returned, which breaks the method's signature and throws a `\TypeError`, which **cannot be catched** since it explicitly filters on `\Exception`.

The proposed solution replaces the `catch (Exception)` with a more robust `catch (\Throwable)` to address this issue.