### PR TITLE
Remove redundant constructor check.

### DIFF
--- a/Block/ChangeProvider.php
+++ b/Block/ChangeProvider.php
@@ -55,10 +55,6 @@ class ChangeProvider extends Template
         parent::__construct($context, $data);
         $this->tfa = $tfa;
         $this->session = $session;
-
-        if (!isset($data['provider'])) {
-            throw new \InvalidArgumentException('A provider must be specified');
-        }
     }
 
     /**


### PR DESCRIPTION
Currently, two integrity tests (BlockInstantiationTest and TemplateFilesTest) are failing with the message: "Unable to instantiate 'MSP\TwoFactorAuth\Block\ChangeProvider'". It's caused by data value check in the constructor of the corresponding class. 
This check should be removed, as it does not have any sense. Furthermore, if, for some reason, $data['provider'] is not set, this check totally blocks the possibility of changing 2FA providers.